### PR TITLE
Update incorrect node engine configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {},
   "engines": {
-    "node": "0.12.00"
+    "node": "0.12.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
This allows the application to work on Cloud Foundry based PaaS's, like Bluemix.

The current code will fail on the latest versions of the Node.js buildpack, due to the following logic:
https://github.com/cloudfoundry/nodejs-buildpack/blob/master/lib/binaries.sh#L3
This makes the buildpack think that 0.12.00 does not need to be resolved, and tries to download a matching version of the runtime, which doens't really exist (it's actually 0.12.0, not 0.12.00).